### PR TITLE
Add vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 sdkconfig
 sdkconfig.old
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build/
 sdkconfig
 sdkconfig.old
-.vagrant
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
     # Enable USB
     vb.customize ['modifyvm', :id, '--usb', 'on']
     # Please use your esp device id, run `VBoxManage.exe list usbhost` list devices
-    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'ESP', '--vendorid', '0x1a86', '--productid', '0x7523']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'ESP', '--vendorid', '0x10C4', '--productid', '0xEA60']
     # Disable log
     vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
   end
@@ -29,6 +29,7 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     apt-get -qq update && apt-get -qq upgrade -y
+    apt-get -qq install -y linux-image-extra-virtual
     apt-get -qq install -y gcc git wget make libncurses-dev flex bison gperf python python-pip python-setuptools python-serial python-cryptography python-future python-pyparsing
     if [ ! -d /opt/local/espressif/ ]; then
       mkdir -p /opt/local/espressif/
@@ -42,6 +43,7 @@ Vagrant.configure("2") do |config|
       cd /opt/local/espressif/esp-idf && git pull -q && git submodule --quiet update --init --recursive
     fi
     chown -R vagrant: /opt/local/espressif/
+    usermod -a -G dialout vagrant
   SHELL
   config.vm.provision 'shell', privileged: false, inline: <<-SHELL
     python -m pip install -q --user -r /opt/local/espressif/esp-idf/requirements.txt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+    # Enable USB
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    # Please use your esp device id, run `VBoxManage.exe list usbhost` list devices
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'ESP', '--vendorid', '0x1a86', '--productid', '0x7523']
+    # Disable log
+    vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
+  end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get -qq update && apt-get -qq upgrade -y
+    apt-get -qq install -y gcc git wget make libncurses-dev flex bison gperf python python-pip python-setuptools python-serial python-cryptography python-future python-pyparsing
+    if [ ! -d /opt/local/espressif/ ]; then
+      mkdir -p /opt/local/espressif/
+    fi
+    if [ ! -d /opt/local/espressif/xtensa-esp32-elf/ ]; then
+      wget -qO- https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz | tar xz -C /opt/local/espressif/
+    fi
+    if [ ! -d /opt/local/espressif/esp-idf/ ]; then
+      git clone -q --recursive https://github.com/espressif/esp-idf.git /opt/local/espressif/esp-idf
+    else
+      cd /opt/local/espressif/esp-idf && git pull -q && git submodule --quiet update --init --recursive
+    fi
+    chown -R vagrant: /opt/local/espressif/
+  SHELL
+  config.vm.provision 'shell', privileged: false, inline: <<-SHELL
+    python -m pip install -q --user -r /opt/local/espressif/esp-idf/requirements.txt
+    grep -q "IDF_PATH" /home/vagrant/.profile || echo "export IDF_PATH=\"/opt/local/espressif/esp-idf\"\nexport PATH="/opt/local/espressif/xtensa-esp32-elf/bin:${PATH}"\ncd /vagrant" >> /home/vagrant/.profile
+  SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
   #   # Customize the amount of memory on the VM:
   #   vb.memory = "1024"
     # Enable USB
-    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ['modifyvm', :id, '--usb', 'on']
     # Please use your esp device id, run `VBoxManage.exe list usbhost` list devices
     vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'ESP', '--vendorid', '0x1a86', '--productid', '0x7523']
     # Disable log
@@ -45,6 +45,6 @@ Vagrant.configure("2") do |config|
   SHELL
   config.vm.provision 'shell', privileged: false, inline: <<-SHELL
     python -m pip install -q --user -r /opt/local/espressif/esp-idf/requirements.txt
-    grep -q "IDF_PATH" /home/vagrant/.profile || echo "export IDF_PATH=\"/opt/local/espressif/esp-idf\"\nexport PATH="/opt/local/espressif/xtensa-esp32-elf/bin:${PATH}"\ncd /vagrant" >> /home/vagrant/.profile
+    grep -q 'IDF_PATH' /home/vagrant/.profile || echo "export IDF_PATH=\"/opt/local/espressif/esp-idf\"\nexport PATH=\"/opt/local/espressif/xtensa-esp32-elf/bin:${PATH}\"\ncd /vagrant" >> /home/vagrant/.profile
   SHELL
 end


### PR DESCRIPTION
1. [Installing Vagrant](https://www.vagrantup.com/docs/installation/)  and [VirtualBox](https://www.virtualbox.org/)
2. Run `VBoxManage.exe list usbhost` get VendorId and ProductId, then modify Vagrantfile, see [Connect USB from Virtual Machine using Vagrant and Virtual Box](https://sonnguyen.ws/connect-usb-from-virtual-machine-using-vagrant-and-virtualbox/)
3. Run `vagrant up` start vm
4. Run `vagrant ssh` to exec `make defconfig` etc.